### PR TITLE
Refactor and allow requests for differently cased README files

### DIFF
--- a/src/components/topic-list.js
+++ b/src/components/topic-list.js
@@ -36,19 +36,21 @@ export default class TopicList extends Component {
     });
   }
 
-  prepareRawAwesomeListRequest = () => {
+  getReadmeFile = () => {
     if (!this.props.clickedTopic) {
       return;
     }
+    axios.get(`https://api.github.com/repos/${this.props.clickedTopic}/readme`)
+    .then((res) => {
+      const { data: { download_url } }= res;
+      return this.getRawAwesomeListContent(download_url);;
+    })
+    .catch((error) => {
+      return null;
+  });}
 
-    const uppercasedReadmeUrl = `https://raw.githubusercontent.com/${this.props.clickedTopic}/master/README.md`;
-    const lowercasedReadmeUrl = `https://raw.githubusercontent.com/${this.props.clickedTopic}/master/readme.md`;
-
-    this.getRawAwesomeListContent(uppercasedReadmeUrl, function() {
-      if (this.state.errorMessage.includes('404')) {
-        this.getRawAwesomeListContent(lowercasedReadmeUrl);
-      }
-    });
+  prepareRawAwesomeListRequest = () => {
+    return this.getReadmeFile();
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the Axios requests made to differently cased `README` files of different repositories.

#### Type of change:
- [x] Bug fix (non-breaking change which fixed an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

#### How Has This Been Tested?
- Clone this repository and install requirements using `yarn install` command
- Git checkout to `katherine95:fix-readme-requests`
- Run `yarn start`
- Navigate to Front-end Development and click on CSS Frameworks

#### Checklist:
- [x] README contents of the selected repo displays.

#### Screenshots (if appropriate):
<img width="1437" alt="Screenshot 2019-10-01 at 17 35 44" src="https://user-images.githubusercontent.com/17095461/65972062-f1c27080-e471-11e9-8203-4ce8bb83f30f.png">

